### PR TITLE
chore: consistent CI behaviour

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
+          version: v1.51
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/cli/dependency_resolver.go
+++ b/cli/dependency_resolver.go
@@ -141,6 +141,10 @@ func (r *resolvingInstance) Step() error {
 			return errors.Wrap(err, "failed resolving mod dependencies")
 		}
 
+		sort.Slice(dependencies.Mods, func(i, j int) bool {
+			return dependencies.Mods[i].Mod_reference < dependencies.Mods[j].Mod_reference
+		})
+
 		for _, mod := range dependencies.Mods {
 			modVersions := make([]ModVersion, len(mod.Versions))
 			for i, version := range mod.Versions {

--- a/cli/resolving_test.go
+++ b/cli/resolving_test.go
@@ -41,7 +41,7 @@ func TestProfileResolution(t *testing.T) {
 		},
 	}).Resolve(resolver, nil, math.MaxInt)
 
-	testza.AssertEqual(t, "failed resolving profile dependencies: mod RefinedRDLib version 1.0.6 does not match constraint ^1.0.7", err.Error())
+	testza.AssertEqual(t, "failed resolving profile dependencies: failed resolving dependencies. requires different versions of RefinedRDLib", err.Error())
 
 	_, err = (&Profile{
 		Name: DefaultProfileName,


### PR DESCRIPTION
#### Deterministic resolving order
For the RefinedPower and RefinedRDLib with incompatible versions test, the error depends on the order in which the mods are added to the lockfile. However, ResolveModDependencies does not have a consistent order of the results, so the order in which mods are added was random, meaning reruning the test would sometimes pass and sometimes fail.

#### Pin golangci-lint version
Each minor version bump of golangci-lint can break a project's linting, as new rules might be added which the project does not yet follow. Pinning the version ensures that commits and pull requests do not fail linting on code they have not changed simply because a newer version of golangci-lint is used.
Pinned to v1.51 as v1.52 adds the revive unused-parameter rule, which the current code fails. Updating the code to pass that would result in merge conflicts with the other PRs, so it can be done later