### PR TITLE
#23: Fix missing short help on view mod info scene

### DIFF
--- a/tea/scenes/mods/mod_info.go
+++ b/tea/scenes/mods/mod_info.go
@@ -72,14 +72,14 @@ func NewModInfo(root components.RootModel, parent tea.Model, mod utils.Mod) tea.
 		ready:    false,
 		help:     help.New(),
 		keys: modInfoKeyMap{
-			Up:       key.NewBinding(key.WithHelp("↑/k", "move up")),
-			UpHalf:   key.NewBinding(key.WithHelp("u", "up half page")),
-			UpPage:   key.NewBinding(key.WithHelp("pgup/b", "page up")),
-			Down:     key.NewBinding(key.WithHelp("↓/j", "move down")),
-			DownHalf: key.NewBinding(key.WithHelp("d", "down half page")),
-			DownPage: key.NewBinding(key.WithHelp("pgdn/ /f", "page down")),
-			Help:     key.NewBinding(key.WithHelp("?", "toggle help")),
-			Back:     key.NewBinding(key.WithHelp("q", "back")),
+			Up:       key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "move up")),
+			UpHalf:   key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "up half page")),
+			UpPage:   key.NewBinding(key.WithKeys("pgup", "b"), key.WithHelp("pgup/b", "page up")),
+			Down:     key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "move down")),
+			DownHalf: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "down half page")),
+			DownPage: key.NewBinding(key.WithKeys("pgdn", "f"), key.WithHelp("pgdn/f", "page down")),
+			Help:     key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "toggle help")),
+			Back:     key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "back")),
 		},
 	}
 


### PR DESCRIPTION
Fix missing short help menu from the View Mod Info scene. This was due to the keys being seen as "disabled" due to no WithKeys option provided.

Ticket ref: #23 

![image](https://github.com/satisfactorymodding/ficsit-cli/assets/8268249/cb15d02b-ee1c-4507-91e3-9a6e67d35c56)
