### PR TITLE
#22: Implement sorting and ordering to installed mods list

### DIFF
--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -144,14 +144,14 @@ func (m installedModsList) LoadModData() {
 					ItemTitle: reference,
 					Activate: func(msg tea.Msg, currentModel installedModsList) (tea.Model, tea.Cmd) {
 						return NewModMenu(m.root, currentModel, utils.Mod{
-							Name:      reference,
+							Name:      "[local] " + reference,
 							Reference: reference,
 						}), nil
 					},
 				},
 				Extra: ficsit.ModsModsGetModsModsMod{
 					Id:                reference,
-					Name:              reference,
+					Name:              "[local] " + reference,
 					Mod_reference:     reference,
 					Views:             0,
 					Downloads:         0,

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -149,6 +149,17 @@ func (m installedModsList) LoadModData() {
 						}), nil
 					},
 				},
+				Extra: ficsit.ModsModsGetModsModsMod{
+					Id:                reference,
+					Name:              reference,
+					Mod_reference:     reference,
+					Views:             0,
+					Downloads:         0,
+					Popularity:        0,
+					Hotness:           0,
+					Created_at:        time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+					Last_version_date: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
 			})
 		}
 

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -69,8 +69,8 @@ func NewInstalledMods(root components.RootModel, parent tea.Model) tea.Model {
 		err:          make(chan string),
 	}
 
-	m.sortFieldList = *m.newSortFieldsList(root)
-	m.sortOrderList = *m.newSortOrderList(root)
+	m.sortFieldList = m.newSortFieldsList(root)
+	m.sortOrderList = m.newSortOrderList(root)
 
 	return m
 }
@@ -398,7 +398,7 @@ func (m installedModsList) sortItems(items []list.Item, field sortField, directi
 	return sortedItems
 }
 
-func (m installedModsList) newSortFieldsList(root components.RootModel) *list.Model {
+func (m installedModsList) newSortFieldsList(root components.RootModel) list.Model {
 	sortFieldList := list.New([]list.Item{
 		utils.SimpleItem[installedModsList]{
 			ItemTitle: "Name",
@@ -476,10 +476,10 @@ func (m installedModsList) newSortFieldsList(root components.RootModel) *list.Mo
 		}
 	}
 
-	return &sortFieldList
+	return sortFieldList
 }
 
-func (m installedModsList) newSortOrderList(root components.RootModel) *list.Model {
+func (m installedModsList) newSortOrderList(root components.RootModel) list.Model {
 	sortOrderList := list.New([]list.Item{
 		utils.SimpleItem[installedModsList]{
 			ItemTitle: "Ascending",
@@ -512,5 +512,5 @@ func (m installedModsList) newSortOrderList(root components.RootModel) *list.Mod
 		}
 	}
 
-	return &sortOrderList
+	return sortOrderList
 }

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -17,16 +17,21 @@ import (
 	"github.com/satisfactorymodding/ficsit-cli/tea/utils"
 )
 
-var _ tea.Model = (*installedModsList)(nil)
+var _ tea.Model = (*modsList)(nil)
 
 type installedModsList struct {
-	root   components.RootModel
-	list   list.Model
-	parent tea.Model
-	items  chan listUpdate
-
-	err   chan string
-	error *components.ErrorComponent
+	list              list.Model
+	sortFieldList     list.Model
+	sortOrderList     list.Model
+	root              components.RootModel
+	parent            tea.Model
+	items             chan listUpdate
+	err               chan string
+	error             *components.ErrorComponent
+	sortingField      sortField
+	sortingOrder      sortOrder
+	showSortFieldList bool
+	showSortOrderList bool
 }
 
 func NewInstalledMods(root components.RootModel, parent tea.Model) tea.Model {
@@ -46,17 +51,25 @@ func NewInstalledMods(root components.RootModel, parent tea.Model) tea.Model {
 	l.KeyMap.Quit.SetHelp("q", "back")
 	l.AdditionalShortHelpKeys = func() []key.Binding {
 		return []key.Binding{
+			key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort")),
+			key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "order")),
 			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
 		}
 	}
+	l.AdditionalFullHelpKeys = l.AdditionalShortHelpKeys
 
 	m := &installedModsList{
-		root:   root,
-		list:   l,
-		parent: parent,
-		items:  make(chan listUpdate),
-		err:    make(chan string),
+		root:         root,
+		list:         l,
+		parent:       parent,
+		items:        make(chan listUpdate),
+		sortingField: DefaultModSortingField,
+		sortingOrder: DefaultModSortingOrder,
+		err:          make(chan string),
 	}
+
+	m.sortFieldList = *m.newSortFieldsList(root)
+	m.sortOrderList = *m.newSortOrderList(root)
 
 	return m
 }
@@ -76,23 +89,22 @@ func (m installedModsList) LoadModData() {
 	i := 0
 	for reference := range currentProfile.Mods {
 		r := reference
-		items[i] = utils.SimpleItem[installedModsList]{
-			ItemTitle: reference,
-			Activate: func(msg tea.Msg, currentModel installedModsList) (tea.Model, tea.Cmd) {
-				return NewModMenu(m.root, currentModel, utils.Mod{
-					Name:      r,
-					Reference: r,
-				}), nil
+		items[i] = utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[installedModsList]{
+				ItemTitle: reference,
+				Activate: func(msg tea.Msg, currentModel installedModsList) (tea.Model, tea.Cmd) {
+					return NewModMenu(m.root, currentModel, utils.Mod{
+						Name:      r,
+						Reference: r,
+					}), nil
+				},
 			},
+			Extra: currentProfile.Mods[i],
 		}
 		i++
 	}
 
-	sort.Slice(items, func(i, j int) bool {
-		a := items[i].(utils.SimpleItem[installedModsList])
-		b := items[j].(utils.SimpleItem[installedModsList])
-		return ascDesc(sortOrderDesc, a.ItemTitle < b.ItemTitle)
-	})
+	items = m.sortItems(items, m.sortingField, m.sortingOrder)
 
 	go func() {
 		if len(currentProfile.Mods) == 0 {
@@ -141,11 +153,7 @@ func (m installedModsList) LoadModData() {
 			}
 		}
 
-		sort.Slice(items, func(i, j int) bool {
-			a := items[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
-			b := items[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
-			return ascDesc(sortOrderDesc, a.Extra.Mod_reference < b.Extra.Mod_reference)
-		})
+		items = m.sortItems(items, m.sortingField, m.sortingOrder)
 
 		m.items <- listUpdate{
 			Items: items,
@@ -171,19 +179,54 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch keypress := msg.String(); keypress {
+		case "s":
+			m.showSortFieldList = !m.showSortFieldList
+			return m, nil
+		case "o":
+			m.showSortOrderList = !m.showSortOrderList
+			return m, nil
 		case keys.KeyControlC:
 			return m, tea.Quit
 		case "q":
+			if m.showSortFieldList {
+				m.showSortFieldList = false
+				return m, nil
+			}
+
+			if m.showSortOrderList {
+				m.showSortOrderList = false
+				return m, nil
+			}
+
 			if m.parent != nil {
 				m.parent.Update(m.root.Size())
 				return m.parent, nil
 			}
 			return m, tea.Quit
 		case keys.KeyEnter:
+			if m.showSortFieldList {
+				m.showSortFieldList = false
+				i, ok := m.sortFieldList.SelectedItem().(utils.SimpleItem[installedModsList])
+				if ok {
+					return m.processActivation(i, msg)
+				}
+				return m, nil
+			}
+
+			if m.showSortOrderList {
+				m.showSortOrderList = false
+				i, ok := m.sortOrderList.SelectedItem().(utils.SimpleItem[installedModsList])
+				if ok {
+					return m.processActivation(i, msg)
+				}
+				return m, nil
+			}
+
 			i, ok := m.list.SelectedItem().(utils.SimpleItem[installedModsList])
 			if ok {
 				return m.processActivation(i, msg)
 			}
+
 			i2, ok := m.list.SelectedItem().(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
 			if ok {
 				return m.processActivation(i2.SimpleItem, msg)
@@ -213,14 +256,33 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	if m.showSortFieldList {
+		var cmd tea.Cmd
+		m.sortFieldList, cmd = m.sortFieldList.Update(msg)
+		return m, cmd
+	} else if m.showSortOrderList {
+		var cmd tea.Cmd
+		m.sortOrderList, cmd = m.sortOrderList.Update(msg)
+		return m, cmd
+	}
+
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
 	return m, cmd
 }
 
 func (m installedModsList) View() string {
-	m.list.SetSize(m.list.Width(), m.root.Size().Height-m.root.Height())
-	return lipgloss.JoinVertical(lipgloss.Left, m.root.View(), m.list.View())
+	var bottomList list.Model
+	if m.showSortFieldList {
+		bottomList = m.sortFieldList
+	} else if m.showSortOrderList {
+		bottomList = m.sortOrderList
+	} else {
+		bottomList = m.list
+	}
+
+	bottomList.SetSize(bottomList.Width(), m.root.Size().Height-m.root.Height())
+	return lipgloss.JoinVertical(lipgloss.Left, m.root.View(), bottomList.View())
 }
 
 func (m installedModsList) processActivation(item utils.SimpleItem[installedModsList], msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -235,4 +297,191 @@ func (m installedModsList) processActivation(item utils.SimpleItem[installedMods
 		return m, nil
 	}
 	return m, nil
+}
+
+func (m installedModsList) sortItems(items []list.Item, field sortField, direction sortOrder) []list.Item {
+	sortedItems := make([]list.Item, len(items))
+	copy(sortedItems, items)
+
+	switch field {
+	case sortFieldLastVersionDate:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Last_version_date.Before(b.Extra.Last_version_date))
+		})
+	case sortFieldCreatedAt:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Created_at.Before(b.Extra.Created_at))
+		})
+	case sortFieldName:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Name < b.Extra.Name)
+		})
+	case sortFieldDownloads:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Downloads < b.Extra.Downloads)
+		})
+	case sortFieldViews:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Views < b.Extra.Views)
+		})
+	case sortFieldPopularity:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Popularity < b.Extra.Popularity)
+		})
+	case sortFieldHotness:
+		sort.Slice(sortedItems, func(i, j int) bool {
+			a := sortedItems[i].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			b := sortedItems[j].(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod])
+			return ascDesc(direction, a.Extra.Hotness < b.Extra.Hotness)
+		})
+	}
+
+	return sortedItems
+}
+
+func (m installedModsList) newSortFieldsList(root components.RootModel) *list.Model {
+	sortFieldList := list.New([]list.Item{
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Name",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = "name"
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Last Version Date",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldLastVersionDate
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Creation Date",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldCreatedAt
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Downloads",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldDownloads
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Views",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldViews
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Popularity (recent downloads)",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldPopularity
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Hotness (recent views)",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldHotness
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
+	sortFieldList.SetShowStatusBar(true)
+	sortFieldList.SetShowFilter(false)
+	sortFieldList.SetFilteringEnabled(false)
+	sortFieldList.Title = m.list.Title
+	sortFieldList.Styles = utils.ListStyles
+	sortFieldList.SetSize(m.list.Width(), m.list.Height())
+	sortFieldList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		}
+	}
+
+	return &sortFieldList
+}
+
+func (m installedModsList) newSortOrderList(root components.RootModel) *list.Model {
+	sortOrderList := list.New([]list.Item{
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Ascending",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingOrder = sortOrderAsc
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Descending",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingOrder = sortOrderDesc
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
+	sortOrderList.SetShowStatusBar(true)
+	sortOrderList.SetShowFilter(false)
+	sortOrderList.SetFilteringEnabled(false)
+	sortOrderList.Title = m.list.Title
+	sortOrderList.Styles = utils.ListStyles
+	sortOrderList.SetSize(m.list.Width(), m.list.Height())
+	sortOrderList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		}
+	}
+
+	return &sortOrderList
 }

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/rs/zerolog/log"
 
 	"github.com/satisfactorymodding/ficsit-cli/ficsit"
 	"github.com/satisfactorymodding/ficsit-cli/tea/components"
@@ -99,7 +100,9 @@ func (m installedModsList) LoadModData() {
 					}), nil
 				},
 			},
-			Extra: currentProfile.Mods[i],
+			Extra: ficsit.ModsModsGetModsModsMod{
+				Name: r,
+			},
 		}
 		i++
 	}
@@ -209,6 +212,8 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				i, ok := m.sortFieldList.SelectedItem().(utils.SimpleItem[installedModsList])
 				if ok {
 					return m.processActivation(i, msg)
+				} else {
+					log.Warn().Str("which", "field").Msg("could not cast selected item to simple item")
 				}
 				return m, nil
 			}
@@ -218,6 +223,8 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				i, ok := m.sortOrderList.SelectedItem().(utils.SimpleItem[installedModsList])
 				if ok {
 					return m.processActivation(i, msg)
+				} else {
+					log.Warn().Str("which", "order").Msg("could not cast selected item to simple item")
 				}
 				return m, nil
 			}
@@ -353,81 +360,67 @@ func (m installedModsList) sortItems(items []list.Item, field sortField, directi
 
 func (m installedModsList) newSortFieldsList(root components.RootModel) *list.Model {
 	sortFieldList := list.New([]list.Item{
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Name",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "name"
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Name",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldName
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Last Version Date",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldLastVersionDate
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Last Version Date",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldLastVersionDate
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Creation Date",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldCreatedAt
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Creation Date",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldCreatedAt
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Downloads",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldDownloads
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Downloads",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldDownloads
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Views",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldViews
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Views",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldViews
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Popularity (recent downloads)",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldPopularity
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Popularity (recent downloads)",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldPopularity
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Hotness (recent views)",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = sortFieldHotness
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Hotness (recent views)",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingField = sortFieldHotness
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
 	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
@@ -448,26 +441,22 @@ func (m installedModsList) newSortFieldsList(root components.RootModel) *list.Mo
 
 func (m installedModsList) newSortOrderList(root components.RootModel) *list.Model {
 	sortOrderList := list.New([]list.Item{
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Ascending",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingOrder = sortOrderAsc
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Ascending",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingOrder = sortOrderAsc
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Descending",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingOrder = sortOrderDesc
-					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
+		utils.SimpleItem[installedModsList]{
+			ItemTitle: "Descending",
+			Activate: func(msg tea.Msg, m installedModsList) (tea.Model, tea.Cmd) {
+				m.sortingOrder = sortOrderDesc
+				cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+				m.list.ResetSelected()
+				return m, cmd
 			},
 		},
 	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -134,15 +134,36 @@ func (m installedModsList) LoadModData() {
 			return
 		}
 
-		if len(mods.Mods.Mods) == 0 {
-			return
+		items := make([]list.Item, 0)
+
+		// create a pre-defined list of the mods in the profile, to then update
+		// with modsmodsmodsmods info after
+		for reference := range currentProfile.Mods {
+			items = append(items, utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod]{
+				SimpleItem: utils.SimpleItem[installedModsList]{
+					ItemTitle: reference,
+					Activate: func(msg tea.Msg, currentModel installedModsList) (tea.Model, tea.Cmd) {
+						return NewModMenu(m.root, currentModel, utils.Mod{
+							Name:      reference,
+							Reference: reference,
+						}), nil
+					},
+				},
+			})
 		}
 
-		items := make([]list.Item, len(mods.Mods.Mods))
 		for i, mod := range mods.Mods.Mods {
+			var index *int
+			for exIndex, exItem := range items {
+				if exItem.(utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod]).SimpleItem.ItemTitle == mod.Mod_reference {
+					index = &exIndex
+					break
+				}
+			}
+
 			// Re-reference struct
 			mod := mod
-			items[i] = utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod]{
+			item := utils.SimpleItemExtra[installedModsList, ficsit.ModsModsGetModsModsMod]{
 				SimpleItem: utils.SimpleItem[installedModsList]{
 					ItemTitle: mods.Mods.Mods[i].Name,
 					Activate: func(msg tea.Msg, currentModel installedModsList) (tea.Model, tea.Cmd) {
@@ -153,6 +174,14 @@ func (m installedModsList) LoadModData() {
 					},
 				},
 				Extra: mod,
+			}
+
+			// if it already exists then replace it with the proper mod,
+			// otherwise we will add it to the end
+			if index != nil {
+				items[*index] = item
+			} else {
+				items = append(items, item)
 			}
 		}
 

--- a/tea/scenes/mods/installed_mods.go
+++ b/tea/scenes/mods/installed_mods.go
@@ -252,9 +252,9 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				i, ok := m.sortFieldList.SelectedItem().(utils.SimpleItem[installedModsList])
 				if ok {
 					return m.processActivation(i, msg)
-				} else {
-					log.Warn().Str("which", "field").Msg("could not cast selected item to simple item")
 				}
+
+				log.Warn().Str("which", "field").Msg("could not cast selected item to simple item")
 				return m, nil
 			}
 
@@ -263,9 +263,9 @@ func (m installedModsList) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				i, ok := m.sortOrderList.SelectedItem().(utils.SimpleItem[installedModsList])
 				if ok {
 					return m.processActivation(i, msg)
-				} else {
-					log.Warn().Str("which", "order").Msg("could not cast selected item to simple item")
 				}
+
+				log.Warn().Str("which", "order").Msg("could not cast selected item to simple item")
 				return m, nil
 			}
 

--- a/tea/scenes/mods/mod_info.go
+++ b/tea/scenes/mods/mod_info.go
@@ -98,6 +98,12 @@ func NewModInfo(root components.RootModel, parent tea.Model, mod utils.Mod) tea.
 			return
 		}
 
+		if fullMod.Mod.Id == "" {
+			// likely does not exist on GQL
+			model.modError <- mod.Reference + " was not found on ficsit.app"
+			return
+		}
+
 		model.modData <- fullMod.Mod
 	}()
 

--- a/tea/scenes/mods/mods.go
+++ b/tea/scenes/mods/mods.go
@@ -23,8 +23,10 @@ import (
 
 var _ tea.Model = (*modsList)(nil)
 
-type sortOrder string
-type sortField string
+type (
+	sortOrder string
+	sortField string
+)
 
 const (
 	sortOrderAsc  sortOrder = "asc"
@@ -50,8 +52,6 @@ type listUpdate struct {
 }
 
 // type keys
-type modsListInterface interface {
-}
 
 type modsList struct {
 	list              list.Model

--- a/tea/scenes/mods/mods.go
+++ b/tea/scenes/mods/mods.go
@@ -475,7 +475,7 @@ func (m modsList) newSortFieldsList(root components.RootModel) list.Model {
 			SimpleItem: utils.SimpleItem[modsList]{
 				ItemTitle: "Name",
 				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "name"
+					m.sortingField = sortFieldName
 					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
 					m.list.ResetSelected()
 					return m, cmd

--- a/tea/scenes/mods/mods.go
+++ b/tea/scenes/mods/mods.go
@@ -24,10 +24,22 @@ import (
 var _ tea.Model = (*modsList)(nil)
 
 type sortOrder string
+type sortField string
 
 const (
 	sortOrderAsc  sortOrder = "asc"
 	sortOrderDesc sortOrder = "desc"
+
+	sortFieldCreatedAt       sortField = "created_at"
+	sortFieldDownloads       sortField = "downloads"
+	sortFieldHotness         sortField = "hotness"
+	sortFieldLastVersionDate sortField = "last_version_date"
+	sortFieldName            sortField = "name"
+	sortFieldPopularity      sortField = "popularity"
+	sortFieldViews           sortField = "views"
+
+	DefaultModSortingOrder sortOrder = sortOrderAsc
+	DefaultModSortingField sortField = sortFieldLastVersionDate
 )
 
 const modsTitle = "Mods"
@@ -38,6 +50,8 @@ type listUpdate struct {
 }
 
 // type keys
+type modsListInterface interface {
+}
 
 type modsList struct {
 	list              list.Model
@@ -48,7 +62,7 @@ type modsList struct {
 	items             chan listUpdate
 	err               chan string
 	error             *components.ErrorComponent
-	sortingField      string
+	sortingField      sortField
 	sortingOrder      sortOrder
 	showSortFieldList bool
 	showSortOrderList bool
@@ -67,7 +81,6 @@ func NewMods(root components.RootModel, parent tea.Model) tea.Model {
 	l.Styles = utils.ListStyles
 	l.SetSize(l.Width(), l.Height())
 	l.KeyMap.Quit.SetHelp("q", "back")
-
 	l.AdditionalShortHelpKeys = func() []key.Binding {
 		return []key.Binding{
 			key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort")),
@@ -77,144 +90,18 @@ func NewMods(root components.RootModel, parent tea.Model) tea.Model {
 	}
 	l.AdditionalFullHelpKeys = l.AdditionalShortHelpKeys
 
-	sortFieldList := list.New([]list.Item{
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Name",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "name"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Last Version Date",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "last_version_date"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Creation Date",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "created_at"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Downloads",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "downloads"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Views",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "views"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Popularity (recent downloads)",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "popularity"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Hotness (recent views)",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingField = "hotness"
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
-	sortFieldList.SetShowStatusBar(true)
-	sortFieldList.SetShowFilter(false)
-	sortFieldList.SetFilteringEnabled(false)
-	sortFieldList.Title = modsTitle
-	sortFieldList.Styles = utils.ListStyles
-	sortFieldList.SetSize(l.Width(), l.Height())
-	sortFieldList.AdditionalShortHelpKeys = func() []key.Binding {
-		return []key.Binding{
-			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-		}
-	}
-
-	sortOrderList := list.New([]list.Item{
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Ascending",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingOrder = sortOrderAsc
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
-			SimpleItem: utils.SimpleItem[modsList]{
-				ItemTitle: "Descending",
-				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
-					m.sortingOrder = sortOrderDesc
-					cmd := m.list.SetItems(sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
-					m.list.ResetSelected()
-					return m, cmd
-				},
-			},
-		},
-	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
-	sortOrderList.SetShowStatusBar(true)
-	sortOrderList.SetShowFilter(false)
-	sortOrderList.SetFilteringEnabled(false)
-	sortOrderList.Title = modsTitle
-	sortOrderList.Styles = utils.ListStyles
-	sortOrderList.SetSize(l.Width(), l.Height())
-	sortOrderList.AdditionalShortHelpKeys = func() []key.Binding {
-		return []key.Binding{
-			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-		}
-	}
-
 	m := &modsList{
-		root:          root,
-		list:          l,
-		parent:        parent,
-		items:         make(chan listUpdate),
-		sortingField:  "last_version_date",
-		sortingOrder:  sortOrderDesc,
-		sortFieldList: sortFieldList,
-		sortOrderList: sortOrderList,
-		err:           make(chan string),
+		root:         root,
+		list:         l,
+		parent:       parent,
+		items:        make(chan listUpdate),
+		sortingField: DefaultModSortingField,
+		sortingOrder: DefaultModSortingOrder,
+		err:          make(chan string),
 	}
+
+	m.sortFieldList = *m.newSortFieldsList(root)
+	m.sortOrderList = *m.newSortOrderList(root)
 
 	go func() {
 		items := make([]list.Item, 0)
@@ -405,48 +292,48 @@ func (m modsList) View() string {
 	return lipgloss.JoinVertical(lipgloss.Left, m.root.View(), bottomList.View())
 }
 
-func sortItems(items []list.Item, field string, direction sortOrder) []list.Item {
+func (m modsList) sortItems(items []list.Item, field sortField, direction sortOrder) []list.Item {
 	sortedItems := make([]list.Item, len(items))
 	copy(sortedItems, items)
 
 	switch field {
-	case "last_version_date":
+	case sortFieldLastVersionDate:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Last_version_date.Before(b.Extra.Last_version_date))
 		})
-	case "created_at":
+	case sortFieldCreatedAt:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Created_at.Before(b.Extra.Created_at))
 		})
-	case "name":
+	case sortFieldName:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Name < b.Extra.Name)
 		})
-	case "downloads":
+	case sortFieldDownloads:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Downloads < b.Extra.Downloads)
 		})
-	case "views":
+	case sortFieldViews:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Views < b.Extra.Views)
 		})
-	case "popularity":
+	case sortFieldPopularity:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			return ascDesc(direction, a.Extra.Popularity < b.Extra.Popularity)
 		})
-	case "hotness":
+	case sortFieldHotness:
 		sort.Slice(sortedItems, func(i, j int) bool {
 			a := sortedItems[i].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
 			b := sortedItems[j].(utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod])
@@ -580,4 +467,139 @@ func (c ListDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 	}
 
 	fmt.Fprintf(w, "%s", title)
+}
+
+func (m modsList) newSortFieldsList(root components.RootModel) *list.Model {
+	sortFieldList := list.New([]list.Item{
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Name",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = "name"
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Last Version Date",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldLastVersionDate
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Creation Date",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldCreatedAt
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Downloads",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldDownloads
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Views",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldViews
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Popularity (recent downloads)",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldPopularity
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Hotness (recent views)",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingField = sortFieldHotness
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
+	sortFieldList.SetShowStatusBar(true)
+	sortFieldList.SetShowFilter(false)
+	sortFieldList.SetFilteringEnabled(false)
+	sortFieldList.Title = m.list.Title
+	sortFieldList.Styles = utils.ListStyles
+	sortFieldList.SetSize(m.list.Width(), m.list.Height())
+	sortFieldList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		}
+	}
+
+	return &sortFieldList
+}
+
+func (m modsList) newSortOrderList(root components.RootModel) *list.Model {
+	sortOrderList := list.New([]list.Item{
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Ascending",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingOrder = sortOrderAsc
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
+			SimpleItem: utils.SimpleItem[modsList]{
+				ItemTitle: "Descending",
+				Activate: func(msg tea.Msg, m modsList) (tea.Model, tea.Cmd) {
+					m.sortingOrder = sortOrderDesc
+					cmd := m.list.SetItems(m.sortItems(m.list.Items(), m.sortingField, m.sortingOrder))
+					m.list.ResetSelected()
+					return m, cmd
+				},
+			},
+		},
+	}, utils.NewItemDelegate(), root.Size().Width, root.Size().Height-root.Height())
+	sortOrderList.SetShowStatusBar(true)
+	sortOrderList.SetShowFilter(false)
+	sortOrderList.SetFilteringEnabled(false)
+	sortOrderList.Title = m.list.Title
+	sortOrderList.Styles = utils.ListStyles
+	sortOrderList.SetSize(m.list.Width(), m.list.Height())
+	sortOrderList.AdditionalShortHelpKeys = func() []key.Binding {
+		return []key.Binding{
+			key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		}
+	}
+
+	return &sortOrderList
 }

--- a/tea/scenes/mods/mods.go
+++ b/tea/scenes/mods/mods.go
@@ -100,8 +100,8 @@ func NewMods(root components.RootModel, parent tea.Model) tea.Model {
 		err:          make(chan string),
 	}
 
-	m.sortFieldList = *m.newSortFieldsList(root)
-	m.sortOrderList = *m.newSortOrderList(root)
+	m.sortFieldList = m.newSortFieldsList(root)
+	m.sortOrderList = m.newSortOrderList(root)
 
 	go func() {
 		items := make([]list.Item, 0)
@@ -469,7 +469,7 @@ func (c ListDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 	fmt.Fprintf(w, "%s", title)
 }
 
-func (m modsList) newSortFieldsList(root components.RootModel) *list.Model {
+func (m modsList) newSortFieldsList(root components.RootModel) list.Model {
 	sortFieldList := list.New([]list.Item{
 		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
 			SimpleItem: utils.SimpleItem[modsList]{
@@ -561,10 +561,10 @@ func (m modsList) newSortFieldsList(root components.RootModel) *list.Model {
 		}
 	}
 
-	return &sortFieldList
+	return sortFieldList
 }
 
-func (m modsList) newSortOrderList(root components.RootModel) *list.Model {
+func (m modsList) newSortOrderList(root components.RootModel) list.Model {
 	sortOrderList := list.New([]list.Item{
 		utils.SimpleItemExtra[modsList, ficsit.ModsModsGetModsModsMod]{
 			SimpleItem: utils.SimpleItem[modsList]{
@@ -601,5 +601,5 @@ func (m modsList) newSortOrderList(root components.RootModel) *list.Model {
 		}
 	}
 
-	return &sortOrderList
+	return sortOrderList
 }


### PR DESCRIPTION
- Implement ability to sort mod installed list by same filters as mod list
- Handle mod not found on GQL gracefully in mod info scene
- Handle local mods in mod installed list
- [x] TODO: Handle enable/disable of local only mods
- [ ] TODO: Handle apply of local only mods
- [x] TODO: Replace referenced/dereferenced (does no benefit, remnant of testing) sort mod list with generic modList sorting for both types of list
- [x] TODO: Fix "name" in modsList sortField