### PR TITLE
perf(ftp): reduce number of ftp commands run in install preparation

### DIFF
--- a/cli/disk/ftp.go
+++ b/cli/disk/ftp.go
@@ -138,15 +138,11 @@ func (l *ftpDisk) existsWithLock(res *puddle.Resource[*ftp.ServerConn], p string
 		}
 	} else {
 		if errors.As(err, &protocolError) {
-			switch protocolError.Code {
-			case ftp.StatusFileUnavailable:
+			if protocolError.Code == ftp.StatusFileUnavailable {
 				return false, nil
-			default:
-				// We won't handle any other kind of error, see above.
-				return false, fmt.Errorf("failed to list path: %w", err)
 			}
 		}
-		// This is a non-protocol error, see above.
+		// We won't handle any other kind of error, see above.
 		return false, fmt.Errorf("failed to list path: %w", err)
 	}
 
@@ -168,17 +164,13 @@ func (l *ftpDisk) existsWithLock(res *puddle.Resource[*ftp.ServerConn], p string
 	}
 
 	if errors.As(err, &protocolError) {
-		switch protocolError.Code {
-		case ftp.StatusFileUnavailable:
+		if protocolError.Code == ftp.StatusFileUnavailable {
 			return false, nil
-		default:
-			// We won't handle any other kind of error, see above.
-			return false, fmt.Errorf("failed to list path: %w", err)
 		}
 	}
 
-	// This is a non-protocol error, see above.
-	return false, fmt.Errorf("failed to list path: %w", err)
+	// We won't handle any other kind of error, see above.
+	return false, fmt.Errorf("failed to list parent path: %w", err)
 }
 
 func (l *ftpDisk) Exists(p string) (bool, error) {

--- a/cli/disk/ftp.go
+++ b/cli/disk/ftp.go
@@ -11,6 +11,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -312,7 +313,14 @@ func (l *ftpDisk) ReadDir(path string) ([]Entry, error) {
 
 	defer res.Release()
 
-	return l.readDirLock(res, path)
+	entries, err := l.readDirLock(res, path)
+	if err != nil {
+		return nil, err
+	}
+	entries = slices.DeleteFunc(entries, func(i Entry) bool {
+		return i.Name() == "." || i.Name() == ".."
+	})
+	return entries, nil
 }
 
 func (l *ftpDisk) readDirLock(res *puddle.Resource[*ftp.ServerConn], path string) ([]Entry, error) {

--- a/cli/disk/ftp.go
+++ b/cli/disk/ftp.go
@@ -3,12 +3,14 @@ package disk
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"log/slog"
+	"net/textproto"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -91,7 +93,94 @@ func testFTP(u *url.URL, options ...ftp.DialOption) (*ftp.ServerConn, bool, erro
 	return c, false, nil
 }
 
-func (l *ftpDisk) Exists(path string) (bool, error) {
+func (l *ftpDisk) existsWithLock(res *puddle.Resource[*ftp.ServerConn], p string) (bool, error) {
+	slog.Debug("checking if file exists", slog.String("path", clean(p)), slog.String("schema", "ftp"))
+
+	var protocolError *textproto.Error
+
+	_, err := res.Value().GetEntry(clean(p))
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.As(err, &protocolError) {
+		switch protocolError.Code {
+		case ftp.StatusFileUnavailable:
+			return false, nil
+		case ftp.StatusNotImplemented:
+			// GetEntry uses MLST, which might not be supported by the server.
+			// Even though in this case the error is not coming from the server,
+			// the ftp library still returns it as a protocol error.
+		default:
+			// We won't handle any other kind of error, such as
+			// * temporary errors (4xx) - should be retried after a while, so we won't deal with the delay
+			// * connection errors (x2x) - can't really do anything about them
+			// * authentication errors (x3x) - can't do anything about them
+			return false, fmt.Errorf("failed to get path info: %w", err)
+		}
+	} else {
+		// This is a non-protocol error, so we can't be sure what it means.
+		return false, fmt.Errorf("failed to get path info: %w", err)
+	}
+
+	// In case MLST is not supported, we can try to LIST the target path.
+	// We can be sure that List() will actually execute LIST and not MLSD,
+	// since MLST was not supported in the previous step.
+	entries, err := res.Value().List(clean(p))
+	if err == nil {
+		if len(entries) > 0 {
+			// Some server implementations return an empty list for a nonexistent path,
+			// so we cannot be sure that no error means a directory exists unless it also contains some items.
+			// For files, when they exist, they will be listed as a single entry.
+			// TODO: so far the servers (just one) this was happening on also listed . and .. for valid dirs, because it was using `LIST -a`. Is that behaviour consistent that we can rely on it?
+			return true, nil
+		}
+	} else {
+		if errors.As(err, &protocolError) {
+			switch protocolError.Code {
+			case ftp.StatusFileUnavailable:
+				return false, nil
+			default:
+				// We won't handle any other kind of error, see above.
+				return false, fmt.Errorf("failed to list path: %w", err)
+			}
+		}
+		// This is a non-protocol error, see above.
+		return false, fmt.Errorf("failed to list path: %w", err)
+	}
+
+	// If we got here, either the path is an empty directory,
+	// or it does not exist and the server is a weird implementation.
+
+	// List the parent directory to determine if the path exists
+	dir, err := l.readDirLock(res, path.Dir(clean(p)))
+	if err == nil {
+		found := false
+		for _, entry := range dir {
+			if entry.Name() == path.Base(clean(p)) {
+				found = true
+				break
+			}
+		}
+
+		return found, nil
+	}
+
+	if errors.As(err, &protocolError) {
+		switch protocolError.Code {
+		case ftp.StatusFileUnavailable:
+			return false, nil
+		default:
+			// We won't handle any other kind of error, see above.
+			return false, fmt.Errorf("failed to list path: %w", err)
+		}
+	}
+
+	// This is a non-protocol error, see above.
+	return false, fmt.Errorf("failed to list path: %w", err)
+}
+
+func (l *ftpDisk) Exists(p string) (bool, error) {
 	res, err := l.acquire()
 	if err != nil {
 		return false, err
@@ -99,49 +188,7 @@ func (l *ftpDisk) Exists(path string) (bool, error) {
 
 	defer res.Release()
 
-	slog.Debug("checking if file exists", slog.String("path", clean(path)), slog.String("schema", "ftp"))
-
-	split := strings.Split(clean(path)[1:], "/")
-	for _, s := range split[:len(split)-1] {
-		dir, err := l.readDirLock(res, "")
-		if err != nil {
-			return false, err
-		}
-
-		currentDir, _ := res.Value().CurrentDir()
-
-		foundDir := false
-		for _, entry := range dir {
-			if entry.IsDir() && entry.Name() == s {
-				foundDir = true
-				break
-			}
-		}
-
-		if !foundDir {
-			return false, nil
-		}
-
-		slog.Debug("entering directory", slog.String("dir", s), slog.String("cwd", currentDir), slog.String("schema", "ftp"))
-		if err := res.Value().ChangeDir(s); err != nil {
-			return false, fmt.Errorf("failed to enter directory: %w", err)
-		}
-	}
-
-	dir, err := l.readDirLock(res, "")
-	if err != nil {
-		return false, fmt.Errorf("failed listing directory: %w", err)
-	}
-
-	found := false
-	for _, entry := range dir {
-		if entry.Name() == clean(filepath.Base(path)) {
-			found = true
-			break
-		}
-	}
-
-	return found, nil
+	return l.existsWithLock(res, p)
 }
 
 func (l *ftpDisk) Read(path string) ([]byte, error) {

--- a/cli/installations.go
+++ b/cli/installations.go
@@ -674,10 +674,6 @@ type gameVersionFile struct {
 }
 
 func (i *Installation) GetGameVersion(ctx *GlobalContext) (int, error) {
-	if err := i.Validate(ctx); err != nil {
-		return 0, fmt.Errorf("failed to validate installation: %w", err)
-	}
-
 	platform, err := i.GetPlatform(ctx)
 	if err != nil {
 		return 0, err
@@ -689,14 +685,6 @@ func (i *Installation) GetGameVersion(ctx *GlobalContext) (int, error) {
 	}
 
 	fullPath := filepath.Join(i.BasePath(), platform.VersionPath)
-	exists, err := d.Exists(fullPath)
-	if err != nil {
-		return 0, err
-	}
-
-	if !exists {
-		return 0, errors.New("game version file does not exist")
-	}
 
 	file, err := d.Read(fullPath)
 	if err != nil {


### PR DESCRIPTION
When connecting to an FTP server not on the same network, the latency for every FTP command being run greatly increases, slowing down the install process, which SMM frequently triggers.

Testing this using SirDigby's server, the latency was around 0.3s, and I observed 20 seconds being spent before even starting to extract mods. This PR reduces that time to ~5 seconds.

Improvements made:
* ftp.Exists - consider the error codes returned by MLST or LIST to determine whether a path exists
    * previously it would check for every path segment whether it exists, resulting in longer wait times the deeper the server is located
    * improved install by ~10s
* ftp.MkDir - find last existing segment by checking up rather than down
    * it is very likely that only one or two directories have to be created, so only a couple of path existence checks will be made
    * improved install by ~1s
    * also greatly improves mod extraction (not benchmarked, but previously the throughput would drop to 100B/s average at time, since a lot of directories have to be created)
* parallelize mod removal
    * mod extraction was done in parallel, so there's no reason why deletion shouldn't too
    * one mod removal takes around 6s (not included in the 20s of the benchmark)
* i.Validate - parallelize
    * it is not performed concurrently with any other FTP operation, so it has the whole connection pool available
    * improved install by ~2.5s
* fewer Validate and GetPlatform calls - obtain platform once and pass it to other function calls
    * Validate was being called 6 times, and GetPlatform 4 times
    * improved install by ~1.5s

Additionally, `.` and `..` are ignored in `ReadDir` results, as non-standard FTP servers that use `LIST -a` would return those too, leaving the possibility of the game dir being deleted if it contained a `.smm` file